### PR TITLE
Make pokecord work on Red 3.5

### DIFF
--- a/pokecord/__init__.py
+++ b/pokecord/__init__.py
@@ -4,4 +4,4 @@ from .pokecord import Pokecord
 async def setup(bot):
     cog = Pokecord(bot)
     await cog.initalize()
-    bot.add_cog(cog)
+    await bot.add_cog(cog)

--- a/pokecord/abc.py
+++ b/pokecord/abc.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-from redbot.core import Config
+from redbot.core import Config, commands
 from redbot.core.bot import Red
 
 
@@ -32,3 +32,9 @@ class MixinMeta(ABC):
     @abstractmethod
     def get_name(self):
         raise NotImplementedError
+
+    @commands.group(name="poke")
+    async def poke(self, ctx: commands.Context):
+        """
+        Pokecord commands
+        """

--- a/pokecord/dev.py
+++ b/pokecord/dev.py
@@ -9,8 +9,9 @@ from redbot.core.i18n import Translator
 from redbot.core.utils.chat_formatting import *
 
 from .abc import MixinMeta
-from .pokemixin import poke
 from .statements import *
+
+poke = MixinMeta.poke
 
 _ = Translator("Pokecord", __file__)
 

--- a/pokecord/general.py
+++ b/pokecord/general.py
@@ -1,6 +1,7 @@
 import asyncio
 import copy
 import json
+from typing import Union
 
 import discord
 import tabulate
@@ -13,8 +14,9 @@ from .abc import MixinMeta
 from .converters import Args
 from .functions import chunks, poke_embed
 from .menus import GenericMenu, PokedexFormat, PokeList, PokeListMenu, SearchFormat
-from .pokemixin import poke
 from .statements import *
+
+poke = MixinMeta.poke
 
 _ = Translator("Pokecord", __file__)
 

--- a/pokecord/info.json
+++ b/pokecord/info.json
@@ -7,6 +7,7 @@
     "disabled": false,
     "short": "Pokecord for Red.",
     "description": "Pokecord for Red.",
+    "min_bot_version": "3.5.0",
     "tags": [
         "pokemon",
         "pokecord"

--- a/pokecord/pokecord.py
+++ b/pokecord/pokecord.py
@@ -17,7 +17,6 @@ from redbot.core.utils.chat_formatting import escape, humanize_list
 
 from .dev import Dev
 from .general import GeneralMixin
-from .pokemixin import PokeMixin
 from .settings import SettingsMixin
 from .statements import *
 from .trading import TradeMixin
@@ -44,7 +43,6 @@ class Pokecord(
     TradeMixin,
     SettingsMixin,
     GeneralMixin,
-    PokeMixin,
     commands.Cog,
     metaclass=CompositeMetaClass,
 ):

--- a/pokecord/settings.py
+++ b/pokecord/settings.py
@@ -4,7 +4,8 @@ from redbot.core.i18n import Translator
 from redbot.core.utils.chat_formatting import humanize_list
 
 from .abc import MixinMeta
-from .pokemixin import poke
+
+poke = MixinMeta.poke
 
 _ = Translator("Pokecord", __file__)
 

--- a/pokecord/trading.py
+++ b/pokecord/trading.py
@@ -10,8 +10,9 @@ from redbot.core.utils.chat_formatting import *
 from redbot.core.utils.predicates import MessagePredicate
 
 from .abc import MixinMeta
-from .pokemixin import poke
 from .statements import *
+
+poke = MixinMeta.poke
 
 _ = Translator("Pokecord", __file__)
 


### PR DESCRIPTION
This required changing how the poke command was mixed in with each file due to changes in discord.py 2.0.